### PR TITLE
waterfall passes arguments even if there is an error

### DIFF
--- a/lib/flow.js
+++ b/lib/flow.js
@@ -253,7 +253,7 @@ module.exports.waterfall = function (tasks, callback) {
             called = true;
 
             if (err) {
-                return callback(err);
+                return callback.apply(err, arguments);
             }
 
             ++completed;

--- a/lib/flow.js
+++ b/lib/flow.js
@@ -253,12 +253,12 @@ module.exports.waterfall = function (tasks, callback) {
             called = true;
 
             if (err) {
-                return callback.apply(err, arguments);
+                return callback(...arguments);
             }
 
             ++completed;
             if (completed === size) {
-                return callback.apply(null, arguments);
+                return callback(...arguments);
             }
 
             const l = arguments.length;

--- a/test/insync.js
+++ b/test/insync.js
@@ -1954,17 +1954,19 @@ describe('Insync', function () {
                         setTimeout(function () {
 
                             callOrder.push(1);
-                            callback(new Error('foo'));
+                            callback(new Error('foo'), arg0, 5);
                         }, 2);
                     },
                     function (callback) {
 
                         expect(false).to.equal(true);
                     }
-                ], function (err) {
+                ], function (err, arg1, arg2) {
 
                     expect(err).to.exist();
                     expect(callOrder).to.deep.equal([0, 1]);
+                    expect(arg1).to.equal(0);
+                    expect(arg2).to.equal(5);
                     done();
                 });
             });


### PR DESCRIPTION
If a task returns an error, also returns the other arguments that the task passes in.
It helps to pass some state through for cleanup during errors.
